### PR TITLE
fix(tag, release): add tagging for images to maintain consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     env:
-      TAG: ${{ github.sha }}
       IMAGE_ORG: 'raspbernetes'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "::set-env name=TAG::${CI_TAG}"
+          echo "::set-env name=BRANCH::{BRANCH}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -41,20 +50,28 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.ndm
+          make buildx.push.ndm
 
   ndm-exporter:
     runs-on: ubuntu-latest
     needs: lint
     env:
-      TAG: ${{ github.sha }}
       IMAGE_ORG: 'raspbernetes'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "::set-env name=TAG::${CI_TAG}"
+          echo "::set-env name=BRANCH::{BRANCH}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -69,10 +86,9 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.exporter
+          make buildx.push.exporter
 
   ndm-operator:
     runs-on: ubuntu-latest
@@ -84,6 +100,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "::set-env name=TAG::${CI_TAG}"
+          echo "::set-env name=BRANCH::{BRANCH}"
+
       - name: Set up Docker Buildx
         id: buildx
         uses: crazy-max/ghaction-docker-buildx@v1
@@ -97,7 +123,6 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.ndo
+          make buildx.push.ndo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: release
 
 on:
   create:
-    branches:
-      - master
     tags:
       - 'v*'
 
@@ -11,11 +9,15 @@ jobs:
   ndm-daemonset:
     runs-on: ubuntu-latest
     env:
-      TAG: $(git describe --abbrev=0)
       IMAGE_ORG: 'raspbernetes'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=RELEASE_TAG::${TAG}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -24,25 +26,29 @@ jobs:
           version: latest
 
       - name: Login to GitHub Docker Registry
-        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+        run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.ndm
+          make buildx.push.ndm
 
   ndm-exporter:
     runs-on: ubuntu-latest
     env:
-      TAG: $(git describe --abbrev=0)
       IMAGE_ORG: 'raspbernetes'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=RELEASE_TAG::${TAG}"
+
 
       - name: Set up Docker Buildx
         id: buildx
@@ -57,19 +63,23 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.exporter
+          make buildx.push.exporter
 
   ndm-operator:
     runs-on: ubuntu-latest
     env:
-      TAG: $(git describe --abbrev=0)
       IMAGE_ORG: 'raspbernetes'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=RELEASE_TAG::${TAG}"
+
 
       - name: Set up Docker Buildx
         id: buildx
@@ -84,7 +94,6 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: raspbernetes
         run: |
           make docker.buildx.ndo
+          make buildx.push.ndo

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -18,7 +18,7 @@
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
 
 ifeq (${TAG}, )
-  export TAG="ci"
+  export TAG=ci
 endif
 
 # Initialize the NDM DaemonSet variables
@@ -112,3 +112,15 @@ docker.buildx.exporter:
 install-dep-nonsudo:
 	@echo "--> Installing external dependencies for building node-disk-manager"
 	$(PWD)/build/install-dep.sh
+
+.PHONY: buildx.push.ndm
+buildx.push.ndm:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/node-disk-manager ./build/push
+
+.PHONY: buildx.push.exporter
+buildx.push.exporter:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/node-disk-exporter ./build/push
+
+.PHONY: buildx.push.ndo
+buildx.push.ndo:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/node-disk-operator ./build/push

--- a/build/push
+++ b/build/push
@@ -22,6 +22,30 @@ then
   exit 1
 fi
 
+function pushBuildx() {
+  BUILD_TAG="latest"
+  TARGET_IMG=${DIMAGE}
+
+# TODO Currently ci builds with commit tag will not be generated,
+# since buildx does not support multiple repo
+  # if not a release build set the tag and ci image
+  if [ -z "${RELEASE_TAG}" ]; then
+    return
+#    BUILD_ID=$(git describe --tags --always)
+#    BUILD_TAG="${BRANCH}-${BUILD_ID}"
+#    TARGET_IMG="${DIMAGE}-ci"
+  fi
+
+  echo "Tagging and pushing ${DIMAGE}:${TAG} as ${TARGET_IMG}:${BUILD_TAG}"
+  docker buildx imagetools create "${DIMAGE}:${TAG}" -t "${TARGET_IMG}:${BUILD_TAG}"
+}
+
+# if the push is for a buildx build
+if [[ ${BUILDX} ]]; then
+  pushBuildx
+  exit 0
+fi
+
 IMAGEID=$( sudo docker images -q ${DIMAGE}:ci )
 echo "${DIMAGE}:ci -> $IMAGEID"
 if [ -z ${IMAGEID} ];


### PR DESCRIPTION
The tag generation and push script has been modified.

Images pushed:
1. For every release, 3 images will be pushed: 
     1. `image:latest`
     2. `image:<release-tag>`
     3. `image:<release-tag>-ci`
2. For every push:
     1. `image:ci` (for master branch) and `image:<branch>-ci` (for all other branches)

The release tag and branch name will be same when a tag is pushed.